### PR TITLE
Add class level options

### DIFF
--- a/lib/minichart/base.rb
+++ b/lib/minichart/base.rb
@@ -3,9 +3,31 @@ module Minichart
   class Base < Victor::SVGBase
     attr_reader :data, :options
 
+    class << self
+      def master_defaults
+        {
+          background: 'white',
+          height: 100,
+          width: 300,
+          stroke: 2,
+          style: {},
+          color: '#66f'
+        }
+      end
+
+      # For subclasses to define
+      def defaults
+        {}
+      end
+
+      def options
+        @options ||= master_defaults.merge defaults
+      end
+    end
+
     def initialize(data, user_options = {})
       @data = data
-      @options = master_defaults.merge(defaults).merge(user_options)
+      @options = self.class.options.merge user_options
 
       super viewBox: viewbox, style: options[:style]
       element :rect, x: 0, y: 0,
@@ -26,22 +48,6 @@ module Minichart
           element :rect, width: options[:width], height: options[:height]
         end
       end
-    end
-
-    def master_defaults
-      {
-        background: 'white',
-        height: 100,
-        width: 300,
-        stroke: 2,
-        style: {},
-        color: '#66f'
-      }
-    end
-
-    # For subclasses
-    def defaults
-      {}
     end
 
     def viewbox

--- a/lib/minichart/meters/horizontal_bar_meter.rb
+++ b/lib/minichart/meters/horizontal_bar_meter.rb
@@ -1,5 +1,11 @@
 module Minichart
   class HorizontalBarMeter < Meter
+    class << self
+      def defaults
+        meter_defaults.merge width: 300, height: 50
+      end
+    end
+
     def build
       draw_bar
       draw_notches if options[:notches]
@@ -7,10 +13,6 @@ module Minichart
     end
 
   protected
-
-    def defaults
-      meter_defaults.merge width: 300, height: 50
-    end
 
     def draw_bar
       x1 = x_for 0

--- a/lib/minichart/meters/meter.rb
+++ b/lib/minichart/meters/meter.rb
@@ -2,6 +2,22 @@ module Minichart
   # Base class for charts with a single value
   class Meter < Base
 
+    class << self
+      def meter_defaults
+        @meter_defaults ||= {
+          height: 50,
+          max: 100,
+          notches: [],
+          notch_thickness: 10,
+          notch_color: 'black',
+          clipping_indicator: false,
+          clipping_indicator_thickness: 20,
+          clipping_indicator_color: 'yellow',
+        }
+      end
+    end
+
+
   protected 
 
     def value
@@ -24,19 +40,6 @@ module Minichart
       else
         options[:mode].to_sym
       end
-    end
-
-    def meter_defaults
-      {
-        height: 50,
-        max: 100,
-        notches: [],
-        notch_thickness: 10,
-        notch_color: 'black',
-        clipping_indicator: false,
-        clipping_indicator_thickness: 20,
-        clipping_indicator_color: 'yellow',
-      }
     end
 
     def clamped_value

--- a/lib/minichart/meters/vertical_bar_meter.rb
+++ b/lib/minichart/meters/vertical_bar_meter.rb
@@ -1,5 +1,11 @@
 module Minichart
   class VerticalBarMeter < Meter
+    class << self
+      def defaults
+        meter_defaults.merge width: 50, height: 300
+      end
+    end
+    
     def build
       draw_bar
       draw_notches if options[:notches]
@@ -7,10 +13,6 @@ module Minichart
     end
 
   protected
-
-    def defaults
-      meter_defaults.merge width: 50, height: 300
-    end
 
     def draw_bar
       y1 = y_for 0

--- a/spec/minichart/base_spec.rb
+++ b/spec/minichart/base_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Base do
+
+  describe "class methods" do
+    # Using a typical subclass
+    subject { LineChart }
+
+    describe '::options' do
+      it "returns default options" do
+        expect(subject.options).to be_a Hash
+        expect(subject.options).to eq subject.master_defaults
+      end
+    end
+
+    describe '::options[]=' do
+      before { @original_background = subject.options[:background] }
+      after  { subject.options[:background] = @original_background }
+      let(:instance) { subject.new [1,2] }
+
+      it "allows overriding instance options at the class level" do
+        subject.options[:background] = 'light-blue'
+        expect(instance.options[:background]).to eq 'light-blue'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow setting defaults by using `::options` on all chart classes, like:

```ruby
AreaChart.options[:background] = 'light-blue'
```

Closes #10